### PR TITLE
Set code_arm_required to false if arming code is undefined.

### DIFF
--- a/custom_components/alarmdotcom/alarm_control_panel.py
+++ b/custom_components/alarmdotcom/alarm_control_panel.py
@@ -77,15 +77,19 @@ class AlarmControlPanel(HardwareBaseDevice, AlarmControlPanelEntity):  # type: i
 
         super().__init__(controller, device)
 
+        arm_code := controller.options.get(CONF_ARM_CODE)
+
         self._attr_code_format = (
             (
                 CodeFormat.NUMBER
                 if (isinstance(arm_code, str) and re.search("^\\d+$", arm_code))
                 else CodeFormat.TEXT
             )
-            if (arm_code := controller.options.get(CONF_ARM_CODE))
+            if arm_code
             else None
         )
+
+        self._attr_code_arm_required = arm_code is not None
 
         self._attr_supported_features = (
             AlarmControlPanelEntityFeature.ARM_HOME | AlarmControlPanelEntityFeature.ARM_AWAY


### PR DESCRIPTION
Set the base `code_arm_required` attribute based on the presence of `CONF_ARM_CODE` in the configuration.

This allows the panel to be armed without having to provide a code, which no longer works after the changes in the base `AlarmControlPanelEntity` introduced in https://github.com/home-assistant/core/pull/112540/commits/f8cbbd36c3d3abf2a72ce21d6786b38e0bc71289.